### PR TITLE
[FIX] Groupless backorders list all sales

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -65,11 +65,12 @@ class StockPicking(models.Model):
         res = super(StockPicking, self)._create_backorder(backorder_moves)
         for picking in self.filtered(lambda pick: pick.picking_type_id.code == 'outgoing'):
             backorder = picking.search([('backorder_id', '=', picking.id)])
-            order = self.env['sale.order'].search([('procurement_group_id', '=', backorder.group_id.id)])
-            backorder.message_post_with_view(
-                'mail.message_origin_link',
-                values={'self': backorder, 'origin': order},
-                subtype_id=self.env.ref('mail.mt_note').id)
+            if backorder.group_id:
+                order = self.env['sale.order'].search([('procurement_group_id', '=', backorder.group_id.id)])
+                backorder.message_post_with_view(
+                    'mail.message_origin_link',
+                    values={'self': backorder, 'origin': order},
+                    subtype_id=self.env.ref('mail.mt_note').id)
         return res
 
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When a backorder is created from a picking that goes to a customer, a message is added that lists the same sale orders as source as the original picking. However, if the picking in question was not created from a sale, the resulting group will be `False`, and so the search for matching sales will find all sales who do not have a procurement group associated. This is basically any unconfirmed sale in the system at that time.

Current behavior before PR:

If you create a backorder from a picking when
1. You have the `sale_stock` module installed (so both the Sale and Inventory apps)
1. The picking is headed to a customer location (so that it is outgoing)
1. The picking is not the result of a sale, but was created manually

When you create a backorder by only gathering the picking partially, the backorder will have a message in its message thread that lists every non-confirmed sale order as the source of that new picking.

Desired behavior after PR is merged:

When a backorder is created from a picking that does not have a sale associated, it should not list sales as sources.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
